### PR TITLE
Add new builder target for easy local development

### DIFF
--- a/app1/angular.json
+++ b/app1/angular.json
@@ -10,6 +10,26 @@
       "sourceRoot": "src",
       "prefix": "app1",
       "architect": {
+        "dev": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/icw",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": false,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": [
+            ]
+          }
+        },
         "build": {
           "builder": "@angular-builders/custom-webpack:browser",
           "options": {
@@ -59,14 +79,9 @@
           }
         },
         "serve": {
-          "builder": "@angular-builders/custom-webpack:dev-server",
+          "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "app1:build"
-          },
-          "configurations": {
-            "production": {
-              "browserTarget": "app1:build:production"
-            }
+            "browserTarget": "app1:dev"
           }
         },
         "extract-i18n": {

--- a/app2/angular.json
+++ b/app2/angular.json
@@ -10,6 +10,26 @@
       "sourceRoot": "src",
       "prefix": "app2",
       "architect": {
+        "dev": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/icw",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": false,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": [
+            ]
+          }
+        },
         "build": {
           "builder": "@angular-builders/custom-webpack:browser",
           "options": {
@@ -59,14 +79,9 @@
           }
         },
         "serve": {
-          "builder": "@angular-builders/custom-webpack:dev-server",
+          "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "app2:build"
-          },
-          "configurations": {
-            "production": {
-              "browserTarget": "app2:build:production"
-            }
+            "browserTarget": "app2:dev"
           }
         },
         "extract-i18n": {


### PR DESCRIPTION
By changing `serve` to use the new builder target: `dev`, which uses `main.ts`, it enables a standard angular development experience. We no longer need to open http://coexisting-angular-microfrontends.surge.sh/ (and override import map) for local development.